### PR TITLE
Fixed start-flink.sh to properly update the configuration file.

### DIFF
--- a/scripts/start-flink.sh
+++ b/scripts/start-flink.sh
@@ -22,8 +22,8 @@ function edit_properties() {
 
   # replace if found, append if not
   grep "^\\s*\($KEY\)" "$CONF" > /dev/null \
-    && sed -i "s/^\\s*\($KEY\)\\s*:\(.*\)$/\1: $VALUE/" "$FILE" \
-    || echo "$RAW_KEY: $RAW_VALUE" >> "$FILE"
+    && sed -i "s/^\\s*\($KEY\)\\s*:\(.*\)$/\1: $VALUE/" "$CONF" \
+    || echo "$RAW_KEY: $RAW_VALUE" >> "$CONF"
 }
 
 edit_properties 'jobmanager.heap.mb' '256'


### PR DESCRIPTION
The configuration refactor missed a couple lines and as a result any configuration rewriting failed. This fixes that.