### PR TITLE
Signal Processing Improvements and Configuration Name Changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ADD scripts/start-flink.sh /usr/bin/
 ADD scripts/supervise-flink.sh /usr/bin/
 ADD supervisor-jobmanager.ini /etc/supervisor.d/
 ADD supervisor-taskmanager.ini /etc/supervisor.d/
+ADD scripts/kill-supervisor.py /usr/bin/
 
 VOLUME /tmp/flink $FLINK_HOME/conf
 

--- a/scripts/kill-supervisor.py
+++ b/scripts/kill-supervisor.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import sys
+import os
+import signal
+
+def write_stdout(s):
+  # only eventlistener protocol messages may be sent to stdout
+  sys.stdout.write(s)
+  sys.stdout.flush()
+
+def write_stderr(s):
+  sys.stderr.write(s)
+  sys.stderr.flush()
+
+if __name__ == '__main__':
+  while 1:
+
+    # transition from ACKNOWLEDGED to READY
+    write_stdout('READY\n')
+
+    # read header line and print it to stderr
+    line = sys.stdin.readline()
+
+    # Ignore input - we always kill supervisord regardless of the event line
+
+    try:
+        pidfile = open('/supervisord.pid', 'r')
+        pid = int(pidfile.readline())
+        os.kill(pid, signal.SIGQUIT)
+    except Exception as e:
+        write_stdout('Could not kill supervisor: ' + e.strerror + '\n')
+
+    # transition from READY to ACKNOWLEDGED
+    write_stdout('RESULT 2\nOK')
+

--- a/scripts/start-flink.sh
+++ b/scripts/start-flink.sh
@@ -22,8 +22,8 @@ function edit_properties() {
 
   # replace if found, append if not
   grep "^\\s*\($KEY\)" "$CONF" > /dev/null \
-    && sed -i "s/^\\s*\($KEY\)\\s*:\(.*\)$/\1: $VALUE/" "$FILE" \
-    || echo "$RAW_KEY: $RAW_VALUE" >> "$FILE"
+    && sed -i "s/^\\s*\($KEY\)\\s*:\(.*\)$/\1: $VALUE/" "$CONF" \
+    || echo "$RAW_KEY: $RAW_VALUE" >> "$CONF"
 }
 
 edit_properties 'jobmanager.heap.mb' '256'

--- a/scripts/supervise-flink.sh
+++ b/scripts/supervise-flink.sh
@@ -14,4 +14,8 @@ case "$FLINK_MANAGER_TYPE" in
     ;;
 esac
 
-supervisord -n -c "/etc/supervisor.d/$CONFIG"
+# Execute supervisord instead of calling it directly so the current process
+# (the shell running this script) is replaced by supervisord and it receives
+# all signals directly from Docker.
+exec supervisord -n -c "/etc/supervisor.d/$CONFIG"
+

--- a/supervisor-jobmanager.ini
+++ b/supervisor-jobmanager.ini
@@ -3,4 +3,11 @@
 [program:flink-jobmanager]
 command = start-flink.sh jobmanager
 autostart = true
-autorestart = true
+autorestart = false
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true
+killasgroup=true
+

--- a/supervisor-jobmanager.ini
+++ b/supervisor-jobmanager.ini
@@ -11,3 +11,8 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 killasgroup=true
 
+[eventlistener:flink-jobmanager_exit]
+command=/usr/bin/kill-supervisor.py
+process_name=flink-jobmanager
+events=PROCESS_STATE_FATAL,PROCESS_STATE_EXITED,PROCESS_STATE_STOPPED
+

--- a/supervisor-taskmanager.ini
+++ b/supervisor-taskmanager.ini
@@ -3,4 +3,11 @@
 [program:flink-taskmanager]
 command = start-flink.sh taskmanager
 autostart = true
-autorestart = true
+autorestart = false
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true
+killasgroup=true
+

--- a/supervisor-taskmanager.ini
+++ b/supervisor-taskmanager.ini
@@ -11,3 +11,8 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 killasgroup=true
 
+[eventlistener:flink-taskmanager_exit]
+command=/usr/bin/kill-supervisor.py
+process_name=flink-taskmanager
+events=PROCESS_STATE_FATAL,PROCESS_STATE_EXITED,PROCESS_STATE_STOPPED
+


### PR DESCRIPTION
I'm hoping to avoid the overhead of splitting this PR into two. These changes modify the image's behavior as follows:

1. Signals sent from Docker are now received by supervisord and properly sent to the start-flink.sh script and consequently the Flink daemon. This means the image properly responds to `docker stop`.
2. Supervisord is killed, and therefore the container, if the Flink daemon fails to start or dies. This may not be desirable when running in Docker standalone but within a Swarm cluster or Kubernetes it's preferable to let the orchestration layer handle restarts rather than the container itself.
3. Environment variables updated to more closely resemble the Flink configuration they overwrite. I also exposed more configuration that can be overridden.
4. I redirected all console logging from the start-flink.sh scripts to stdout so they show up in `docker logs`.
5. Flink process log and job output (flink-*.log and flink-*.out) are now redirected to stdout as well. This also improves the robustness of the tail command and waits for the files to exist before attempting to tail them - removing any race condition during start up.